### PR TITLE
Added function support for default value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6026,9 +6026,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
     },
     "core-js-compat": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@angular/platform-browser": "~13.0.3",
         "@angular/platform-browser-dynamic": "~13.0.3",
         "@angular/router": "~13.0.3",
-        "core-js": "^2.5.4",
+        "core-js": "^3.21.1",
         "rxjs": "^7.4.0",
         "tslib": "^2.0.0",
         "zone.js": "~0.11.4"

--- a/projects/form-generator/package-lock.json
+++ b/projects/form-generator/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "@recursyve/ngx-form-generator",
+    "version": "13.0.0-beta.26",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+    }
+}

--- a/projects/form-generator/package.json
+++ b/projects/form-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/ngx-form-generator",
-    "version": "13.0.0-beta.26",
+    "version": "13.0.0-beta.27",
     "author": "Recursyve",
     "license": "MIT",
     "homepage": "https://github.com/Recursyve/ngx-form-generator",

--- a/projects/form-generator/src/lib/forms/generated-form-control.spec.ts
+++ b/projects/form-generator/src/lib/forms/generated-form-control.spec.ts
@@ -5,6 +5,8 @@ describe("GeneratedFormControl", () => {
     let textControl: GeneratedFormControl<string>;
     let numberControl: GeneratedFormControl<number>;
     let dateControl: GeneratedFormControl<Date>;
+    let defaultValueControl: GeneratedFormControl<string>;
+    let defaultFunctionalValueControl: GeneratedFormControl<string>;
 
     beforeEach(() => {
         textControl = new GeneratedFormControl({
@@ -30,6 +32,22 @@ describe("GeneratedFormControl", () => {
             name: "date",
             validators: [Validators.required]
         });
+
+        defaultValueControl = new GeneratedFormControl({
+            formElementType: "control",
+            type: "String",
+            key: "text",
+            name: "text",
+            defaultValue: "default_value"
+        });
+
+        defaultFunctionalValueControl = new GeneratedFormControl({
+            formElementType: "control",
+            type: "String",
+            key: "text",
+            name: "text",
+            defaultValue: () => "default_value"
+        });
     });
 
     it("Controls should be in invalid state by default", () => {
@@ -46,6 +64,8 @@ describe("GeneratedFormControl", () => {
         expect(textControl.valid).toBeTruthy();
         expect(numberControl.valid).toBeTruthy();
         expect(dateControl.valid).toBeTruthy();
+        expect(defaultValueControl.valid).toBeTruthy();
+        expect(defaultFunctionalValueControl.valid).toBeTruthy();
     });
 
     it("getRawValue should returns value in the good format", () => {
@@ -56,6 +76,8 @@ describe("GeneratedFormControl", () => {
         expect(textControl.getRawValue()).toEqual("TEST");
         expect(numberControl.getRawValue()).toEqual(0);
         expect((dateControl.getRawValue() as Date)).toEqual(new Date(Date.UTC(2019, 4, 28)));
+        expect(defaultValueControl.getRawValue()).toEqual("default_value");
+        expect(defaultFunctionalValueControl.getRawValue()).toEqual("default_value");
 
         numberControl.patchValue(null);
         expect(numberControl.getRawValue()).toEqual(null);

--- a/projects/form-generator/src/lib/forms/generated-form.ts
+++ b/projects/form-generator/src/lib/forms/generated-form.ts
@@ -7,6 +7,7 @@ import { GroupModel } from "../models/group.model";
 import { AsyncValidator } from "../validators/async.validator";
 import { NGX_FORM_GENERATOR_ASYNC_VALIDATORS } from "../validators/constant";
 import { GeneratedControl } from "./generated-control";
+import { ValueUtils } from "../utils/value.utils";
 
 @Injectable()
 export class GeneratedFormGroup<T> extends FormGroup implements GeneratedControl {
@@ -215,7 +216,7 @@ export class GeneratedFormArray<T> extends FormArray implements GeneratedControl
 
 export class GeneratedFormControl<T> extends FormControl implements GeneratedControl {
     constructor(private model: ControlModel, private asyncValidators: AsyncValidator[] = []) {
-        super({ value: model.defaultValue, disabled: model.disabled }, {
+        super({ value: ValueUtils.useOrComputeValue(model.defaultValue), disabled: model.disabled }, {
             validators: model.validators,
             updateOn: model.updateOn
         });

--- a/projects/form-generator/src/lib/handlers/handler.spec.ts
+++ b/projects/form-generator/src/lib/handlers/handler.spec.ts
@@ -24,6 +24,9 @@ class TestA {
 
     @Control({ name: "date" })
     control3: Date;
+
+    @Control({ defaultValue: () => 10 })
+    control4: number;
 }
 
 class TestB {
@@ -35,7 +38,8 @@ class TestB {
         defaultValue: {
             control1: "test",
             control2: 20,
-            control3: null
+            control3: null,
+            control4: () => 20
         }
     })
     group2: TestA;
@@ -99,10 +103,10 @@ class TestC {
 
 describe("Handler Tests", () => {
     describe("Control", () => {
-        it("TestA Metadata should contain three controls", () => {
+        it("TestA Metadata should contain four controls", () => {
             const controls: ControlModel[] = Reflect.getMetadata(CONTROLS, TestA.prototype);
             expect(controls).toBeDefined();
-            expect(controls.length).toBe(3);
+            expect(controls.length).toBe(4);
         });
 
         it("TestA control1 Metadata should be valid", () => {
@@ -129,13 +133,23 @@ describe("Handler Tests", () => {
             expect(control.key).toBe("control3");
             expect(control.type).toBe("Date");
         });
+
+        it ("TestA control4 Metadata should be valid", () => {
+            const control = ControlHandler.getControl(TestA.prototype, "control4");
+            expect(control).toBeDefined();
+            expect(control.name).toBe("control4");
+            expect(control.key).toBe("control4");
+            expect(control.type).toBe("Number");
+            expect(typeof control.defaultValue).toBe("function");
+            expect(control.defaultValue()).toBe(10);
+        });
     });
 
     describe("Group", () => {
-        it("TestB Metadata should contain three controls", () => {
+        it("TestB Metadata should contain four controls", () => {
             const controls: ControlModel[] = Reflect.getMetadata(CONTROLS, TestB.prototype);
             expect(controls).toBeDefined();
-            expect(controls.length).toBe(3);
+            expect(controls.length).toBe(4);
         });
 
         it("TestB group1 Metadata should be valid", () => {
@@ -146,7 +160,7 @@ describe("Handler Tests", () => {
             expect(control.type).toBe("TestA");
             expect(control.validators.length).toBe(1);
             expect(control.children).toBeDefined();
-            expect(control.children.length).toBe(3);
+            expect(control.children.length).toBe(4);
         });
 
         it("TestB control2 Metadata should be valid", () => {
@@ -156,7 +170,7 @@ describe("Handler Tests", () => {
             expect(control.key).toBe("group2");
             expect(control.type).toBe("TestA");
             expect(control.children).toBeDefined();
-            expect(control.children.length).toBe(3);
+            expect(control.children.length).toBe(4);
             expect(control.defaultValue).toEqual({
                 control1: "test",
                 control2: 20,
@@ -171,7 +185,23 @@ describe("Handler Tests", () => {
             expect(control.key).toBe("group3");
             expect(control.type).toBe("TestA");
             expect(control.children).toBeDefined();
-            expect(control.children.length).toBe(3);
+            expect(control.children.length).toBe(4);
+        });
+
+        it("TestB control4 Metadata should be valid", () => {
+            const control = ControlHandler.getControl(TestB.prototype, "group2") as GroupModel;
+            expect(control).toBeDefined();
+            expect(control.name).toBe("group2");
+            expect(control.key).toBe("group2");
+            expect(control.type).toBe("TestA");
+            expect(control.children).toBeDefined();
+            expect(control.children.length).toBe(4);
+            expect(control.defaultValue).toEqual({
+                control1: "test",
+                control2: 20,
+                control3: null,
+                control4: () => 20
+            });
         });
     });
 

--- a/projects/form-generator/src/lib/utils/value.utils.ts
+++ b/projects/form-generator/src/lib/utils/value.utils.ts
@@ -1,0 +1,9 @@
+export class ValueUtils {
+    public static useOrComputeValue(value: any): any {
+        if (typeof value === "function") {
+            return value();
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Quand on faire un @Control({ defaultValue: "abc" }), on peut maintenant passer une fonction comme suit:
`@Control({ defaultValue: () => new Date() })`