### PR TITLE
Added dynamic formgroup generation

### DIFF
--- a/projects/form-generator/src/lib/forms/generated-form.ts
+++ b/projects/form-generator/src/lib/forms/generated-form.ts
@@ -96,6 +96,24 @@ export class GeneratedFormGroup<T> extends FormGroup implements GeneratedControl
         (this.statusChanges as EventEmitter<string>).emit(this.status);
     }
 
+    public addFormGroup(name: string, formGroup: GeneratedFormGroup<any>, options?: { emitEvent?: boolean }): void {
+        const modelIndex = this._models.findIndex((model) => model.name === name);
+        if (modelIndex >= 0) {
+            this._models.splice(modelIndex, 1);
+        }
+
+        this._models.push({
+            instance: formGroup.config.instance,
+            name,
+            key: name,
+            formElementType: "group",
+            type: formGroup.config.name ?? formGroup.config.instance.name,
+            disabled: formGroup.disabled,
+            children: formGroup.config.children
+        } as GroupModel);
+        super.addControl(name, formGroup, options);
+    }
+
     private generateControls() {
         for (const control of this._models) {
             let formControl: AbstractControl;
@@ -302,7 +320,7 @@ export class GeneratedFormControl<T> extends FormControl implements GeneratedCon
             if (control instanceof GeneratedFormControl) {
                 const shouldRevalidate = control.checkDynamicValidators();
                 if (shouldRevalidate || control.model?.condition) {
-                    control.updateValueAndValidity({depth: depth + 1});
+                    control.updateValueAndValidity({ depth: depth + 1 });
                 }
             }
         }

--- a/projects/form-generator/src/lib/ngx-form-generator.factory.ts
+++ b/projects/form-generator/src/lib/ngx-form-generator.factory.ts
@@ -1,7 +1,7 @@
 import { GeneratedFormGroup } from "./forms";
 import { GroupModel } from "./models/group.model";
 import { NgxFormGeneratorScanner } from "./ngx-form-generator.scanner";
-import { AsyncValidator } from "./validators/async.validator";
+import { AsyncValidator } from "./validators";
 
 export function ngxFormGeneratorFactory(provider: any) {
     return (asyncValidators: AsyncValidator[]) => {

--- a/projects/form-generator/src/lib/services/ngx-form-groups.service.ts
+++ b/projects/form-generator/src/lib/services/ngx-form-groups.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable, Optional, Type } from "@angular/core";
+import { AsyncValidator, NGX_FORM_GENERATOR_ASYNC_VALIDATORS } from "../validators";
+import { GeneratedFormGroup } from "../forms";
+import { NgxFormGeneratorScanner } from "../ngx-form-generator.scanner";
+import { GroupModel } from "../models/group.model";
+
+@Injectable()
+export class NgxFormGroupsService {
+    constructor(@Optional() @Inject(NGX_FORM_GENERATOR_ASYNC_VALIDATORS) private asyncValidators: AsyncValidator[] = []) {}
+
+    public generate<T>(formGroupType: Type<T>): GeneratedFormGroup<T> {
+        const formGroup = new GeneratedFormGroup<T>(this.asyncValidators);
+        formGroup.setConfig({
+            instance: formGroupType,
+            children: NgxFormGeneratorScanner.getControls(formGroupType)
+        } as GroupModel);
+        return formGroup;
+    }
+}

--- a/projects/form-generator/src/public-api.ts
+++ b/projects/form-generator/src/public-api.ts
@@ -6,7 +6,8 @@ import { ClassProvider, FactoryProvider, ModuleWithProviders, NgModule, Provider
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { GeneratedFormGroup } from "./lib/forms";
 import { ngxFormGeneratorFactory } from "./lib/ngx-form-generator.factory";
-import { NGX_FORM_GENERATOR_ASYNC_VALIDATORS } from "./lib/validators/constant";
+import { NGX_FORM_GENERATOR_ASYNC_VALIDATORS } from "./lib/validators";
+import { NgxFormGroupsService } from "./lib/services/ngx-form-groups.service";
 
 export interface NgxFormGeneratorOptions {
     asyncValidators?: Provider[];
@@ -14,7 +15,8 @@ export interface NgxFormGeneratorOptions {
 
 // @dynamic
 @NgModule({
-    imports: [FormsModule, ReactiveFormsModule]
+    imports: [FormsModule, ReactiveFormsModule],
+    providers: [NgxFormGroupsService]
 })
 export class NgxFormGeneratorModule {
     public static forRoot(options: NgxFormGeneratorOptions = {}): ModuleWithProviders<NgxFormGeneratorModule> {
@@ -68,3 +70,4 @@ export * from "./lib/forms";
 export * from "./lib/validators";
 export * from "./lib/ngx-form-generator.factory";
 export * from "./lib/handlers/validators.handler";
+export * from "./lib/services/ngx-form-groups.service";


### PR DESCRIPTION
This allows us to create and add new `GenerateFormGroup` to an existing form group at runtime using:

```ts
const formGroup = this.formGroupsService.generate(MyFormGroupType);
this.formGroup.addFormGroup("myFormGroupKey", formGroup);
```